### PR TITLE
Show SIM Slot in Info Column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Features
 
 - Add TLV parsers for Cell Information Types
+- Add SIM information to the packet info column for SIM specific packets
 
 ## [v2.1.0](https://github.com/seemoo-lab/aristoteles/tree/v2.1.0) (13-03-2025)
 


### PR DESCRIPTION
For the QMI Dissector, we find it very helpful to quickly identify which packets are SIM-specific and to which SIM slot they belong in a dual-SIM scenario. Therefore, we added the SIM information to the info column.

With this PR, we would introduce a similar SIM indicator for ARI.