### PR TITLE
Add Generated Direction Header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 - Add TLV parsers for Cell Information Types
 - Add SIM information to the packet info column for SIM specific packets
+- Add Direction Header to most of the packets
 
 ## [v2.1.0](https://github.com/seemoo-lab/aristoteles/tree/v2.1.0) (13-03-2025)
 


### PR DESCRIPTION
Whilst researching with Aristoteles again (it's of ongoing great use! :), I felt the need to filter by packet direction - aka if the packet is going from the main processor to the baseband (OUT) or from the baseband to the processor (IN).

Different from QMI, ARI packets do not include the direction within the packet itself. However, we can often derive the direction from the message name. In 89% of the messages, the name ends with `Req`, `Resp`, `RespCb`, `Rsp`, `RspCb`, `Ind`, or `IndCb`. With some additional pattern-matching tweaks, we can increase the performance to 95% of all message types.