### PR TITLE
Fix watch_frida for Frida 17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add SIM information to the packet info column for SIM specific packets
 - Add Direction Header to most of the packets
 
+### Fixes
+
+- Fix usage of deprecated Frida functions in watch_frida.py
+
 ## [v2.1.0](https://github.com/seemoo-lab/aristoteles/tree/v2.1.0) (13-03-2025)
 
 ### Features

--- a/tools/frida_ari_functions.js
+++ b/tools/frida_ari_functions.js
@@ -16,27 +16,15 @@ class ARIFunctions {
     // Should the script send all ARI messages to python?
     this.catch_msgs = false;
 
-    this._ARIServer_base = Module.getBaseAddress('libARIServer.dylib');
-
-    this._InboundMsgCb_addr = Module.getExportByName(
-      "libARIServer.dylib",
-      "_ZN9AriHostRt12InboundMsgCBEPhm"
-    );
+    let libAriServer = Process.getModuleByName('libARIServer.dylib');
+    this._ARIServer_base = libAriServer.base;
+    this._InboundMsgCb_addr = libAriServer.getExportByName("_ZN9AriHostRt12InboundMsgCBEPhm");
     this._InboundMsgCb = new NativeFunction(this._InboundMsgCb_addr, "int64", [
       "pointer",
       "int64",
     ]);
-
-    this.SendRaw = Module.getExportByName(
-      "libARIServer.dylib",
-      "_ZN9AriHostRt7SendRawEPhjj"
-    );
-
-    this.SendRawInternal = Module.getExportByName(
-      "libARIServer.dylib",
-      "_ZN9AriHostRt18sendRawInternal_nlEPhj"
-    );
-
+    this.SendRaw = libAriServer.getExportByName("_ZN9AriHostRt7SendRawEPhjj");
+    this.SendRawInternal = libAriServer.getExportByName("_ZN9AriHostRt18sendRawInternal_nlEPhj");
     this.SendRawFunc = new NativeFunction(this.SendRaw, "int64", [
       "pointer",
       "int32",


### PR DESCRIPTION
Frida 17.0.0 deprecated some functions [(ref)](https://frida.re/news/2025/05/17/frida-17-0-0-released/). This PR switches to the recommended Frida usage.